### PR TITLE
Remove licensing from L00 - History

### DIFF
--- a/notebook-lessons/00-oss-history.ipynb
+++ b/notebook-lessons/00-oss-history.ipynb
@@ -3,16 +3,34 @@
   {
    "cell_type": "markdown",
    "id": "b6a5657f",
-   "metadata": {},
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-da62b7e69e1eb359",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
    "source": [
-    "# Module 00: The History and Philosophy of Open Source Software\n",
+    "# Module 00 - The History and Philosophy of Open Source Software\n",
     "---"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "d9f4dabc",
-   "metadata": {},
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-95142f46580a2b3b",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
    "source": [
     "## The Printer Story: The Birth of the Free Software Movement\n",
     "\n",
@@ -32,7 +50,16 @@
   {
    "cell_type": "markdown",
    "id": "e872c798",
-   "metadata": {},
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-9c73e1d9a4a66842",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
    "source": [
     "### A Modern Printer Story\n",
     "\n",
@@ -49,13 +76,57 @@
     "\n",
     "**The hardware was perfectly capable, but proprietary firmware arbitrarily prevented its use.**\n",
     "\n",
-    "*Read the full testimonial: [\"The printer story\" redux: a testimonial about the injustice of proprietary firmware](https://www.fsf.org/blogs/community/201cthe-printer-story201d-redux-a-testimonial-about-the-injustice-of-proprietary-firmware)*"
+    "*Read the full testimonial: [\"The printer story\" redux: a testimonial about the injustice of proprietary firmware](https://www.fsf.org/blogs/community/201cthe-printer-story201d-redux-a-testimonial-about-the-injustice-of-proprietary-firmware)*\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa94d712-5a9b-439f-9043-31c383930ee2",
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-c0490d544ec32b9c",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
+   "source": [
+    "### Where It All Started\n",
+    "\n",
+    "For a quick overview of free software, the philosophy behind it, and the differences between free software and proprietary software, watch this excellent video featuring FSF founder Dr. Richard Stallman (and Apple co-founder Steve Wozniak) from 1983:\n",
+    "\n",
+    "[![WATCH: The FOSS Movement Is Born](https://img.youtube.com/vi/oIrXuv-JjeE/hqdefault.jpg)](https://www.youtube.com/watch?v=oIrXuv-JjeE)\n",
+    "\n",
+    "**[WATCH: The FOSS Movement Is Born](https://www.youtube.com/watch?v=oIrXuv-JjeE)**\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Dr. Richard Stallman also gave a talk at Georgia Tech in January 2026, where he discussed the history and philosophy of free software, the importance of software freedom, and the ongoing challenges in the free sofware movement:\n",
+    "\n",
+    "[![WATCH: Dr. Richard Stallman at Georgia Tech](https://img.youtube.com/vi/YDxPJs1EPS4/hqdefault.jpg)](https://www.youtube.com/watch?v=YDxPJs1EPS4)\n",
+    "\n",
+    "**[WATCH: Dr. Richard Stallman at Georgia Tech](https://www.youtube.com/watch?v=YDxPJs1EPS4)**\n",
+    "\n",
+    "---"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "0589d1b9",
-   "metadata": {},
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-cdac48bf18b44542",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
    "source": [
     "## Understanding Software Freedom\n",
     "\n",
@@ -79,61 +150,7 @@
     "\n",
     "An important clarification: **\"Free\" software refers to freedom, not price.** You can charge money for free software. The \"free\" in \"free software\" refers to liberty (as in \"free speech\"), not cost (as in \"free beer\").\n",
     "\n",
-    "What matters is that once someone has the software, they have all four freedoms to use, study, modify, and redistribute it."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3f38ad39",
-   "metadata": {},
-   "source": [
-    "## Types of Software Licenses\n",
-    "\n",
-    "Understanding software licensing is crucial for navigating the open source landscape. Here are the four main categories:\n",
-    "\n",
-    "### 1. Proprietary Software\n",
-    "- **Characteristics:** Closed source, proprietary rights reserved by the owner\n",
-    "- **Examples:** Microsoft Windows, Adobe Photoshop, many commercial applications\n",
-    "- **User Rights:** Very limited; typically just the right to use\n",
-    "\n",
-    "### 2. Source Available\n",
-    "- **Characteristics:** Source code is visible, but comes with restrictions (e.g., no modifications or redistribution)\n",
-    "- **Examples:** Sentry, OctoML, Meta's Llama license(s), other specific enterprise software\n",
-    "- **User Rights:** Can view source but limited modification/redistribution rights\n",
-    "\n",
-    "### 3. Permissive Open Source\n",
-    "- **Characteristics:** Minimal restrictions, allows proprietary derivatives\n",
-    "- **Examples:** MIT/BSD License, Apache 2.0, Mozilla Public License\n",
-    "- **User Rights:** Can use, modify, and redistribute, including in proprietary projects - most permissive licenses (but not all) respect the 4 freedoms of free software\n",
-    "\n",
-    "### 4. Copyleft Open Source\n",
-    "- **Characteristics:** Ensures derivatives remain free; \"viral\" licensing\n",
-    "- **Examples:** GPL (General Public License), LGPL, AGPL\n",
-    "- **User Rights:** All four freedoms guaranteed, with the requirement that derivatives also be free - this distinction is also called \"strong copyleft\" and is the basis of the Free Software Foundation's definition of free software.\n",
-    "\n",
-    "> [!NOTE]\n",
-    "> The Free Software Foundation considers only copyleft licenses that guarantee all four freedoms to be \"free software.\" Many permissive licenses are considered \"free software\" by the Free Software Foundation, but some permissive licenses (e.g., the [Open Watcom License](https://www.gnu.org/philosophy/open-source-misses-the-point.en.html#:~:text=First,such%20licenses)) do not meet the criteria for free software.\n",
-    "\n",
-    "> [!IMPORTANT]\n",
-    "> Free software and Open-Source can be used interchangeably, but they have different philosophical underpinnings. All licenses shown past level 3 (permissive open source) are considered \"free software\" by the Free Software Foundation, but only copyleft licenses (level 4) can guarantee all four freedoms.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Where It All Started\n",
-    "\n",
-    "For a quick overview of free software, the philosophy behind it, and the differences between free software and proprietary software, watch this excellent video featuring FSF founder Dr. Richard Stallman (and Apple co-founder Steve Wozniak) from 1983:\n",
-    "\n",
-    "[![WATCH: The FOSS Movement Is Born](https://img.youtube.com/vi/oIrXuv-JjeE/hqdefault.jpg)](https://www.youtube.com/watch?v=oIrXuv-JjeE)\n",
-    "\n",
-    "**[WATCH: The FOSS Movement Is Born](https://www.youtube.com/watch?v=oIrXuv-JjeE)**\n",
-    "\n",
-    "---\n",
-    "\n",
-    "Dr. Richard Stallman also gave a talk at Georgia Tech in January 2026, where he discussed the history and philosophy of free software, the importance of software freedom, and the ongoing challenges in the free sofware movement:\n",
-    "\n",
-    "[![WATCH: Dr. Richard Stallman at Georgia Tech](https://img.youtube.com/vi/YDxPJs1EPS4/hqdefault.jpg)](https://www.youtube.com/watch?v=YDxPJs1EPS4)\n",
-    "\n",
-    "**[WATCH: Dr. Richard Stallman at Georgia Tech](https://www.youtube.com/watch?v=YDxPJs1EPS4)**\n",
+    "What matters is that once someone has the software, they have all four freedoms to use, study, modify, and redistribute it.\n",
     "\n",
     "---"
    ]
@@ -141,7 +158,16 @@
   {
    "cell_type": "markdown",
    "id": "44874458",
-   "metadata": {},
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-8fc51560e4985ad0",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
    "source": [
     "## Free Software vs. Open Source: Understanding the Difference\n",
     "\n",
@@ -164,33 +190,33 @@
     "\n",
     "### The Relationship\n",
     "\n",
-    "**Important:** While free copyleft software is always open source and respective of the foure freedoms, something that calls itself 'open source software' isn't always free software.\n",
+    "**Important:** While free copyleft software is always open source and respective of the four freedoms, something that calls itself 'open source software' isn't always free software.\n",
     "\n",
-    "- **Free software** → Always open source ✅\n",
-    "- **Open source** → Not always free software ❓\n",
+    "- **Free software** → Always open source\n",
+    "- **Open source** → Not always free software\n",
     "\n",
     "[Some \"open source\" projects may be \"source available\" but lack the full freedoms required for true free software.](https://www.gnu.org/philosophy/open-source-misses-the-point.en.html)\n",
     "\n",
-    "---\n",
+    "For more information on licensing, see `L08 - Licensing.ipynb`\n",
     "\n",
-    "#### GPL-Compatible Licenses\n",
-    "\n",
-    "Any license that meets the criteria for free software (i.e., guarantees all four freedoms) is considered \"GPL-compatible.\" This includes popular licenses such as:\n",
-    "- **Apache 2.0** (recommended for new projects)\n",
-    "- **LGPLv3** (Lesser General Public License - Recommended for copyleft projects)\n",
-    "- **GPLv3** (General Public License)\n",
-    "- **MIT License** Also known as the Expat License\n",
-    "- **BSD Licenses** BSD 2-Clause, BSD 3-Clause, etc.\n",
-    "\n",
-    "For a comprehensive list of free software licenses and their compatibility status, see the [FSF's license list](https://www.gnu.org/licenses/license-list.html), which provides detailed analysis of virtually all modern FLOSS software licenses."
+    "---\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "14636771",
-   "metadata": {},
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-6d33cbae72bb8fcc",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
    "source": [
-    "## Why Open Source is Thriving 🚀\n",
+    "## Why Open Source Thrives\n",
     "\n",
     "Open source software is seeing unprecedented investment and adoption. Here's why:\n",
     "\n",
@@ -223,7 +249,16 @@
   {
    "cell_type": "markdown",
    "id": "1b348c00",
-   "metadata": {},
+   "metadata": {
+    "nbgrader": {
+     "grade": false,
+     "grade_id": "cell-47b69f7591c38740",
+     "locked": true,
+     "schema_version": 3,
+     "solution": false,
+     "task": false
+    }
+   },
    "source": [
     "## Key Takeaways\n",
     "\n",
@@ -231,20 +266,11 @@
     "\n",
     "2. **Four Freedoms:** Free software grants users the freedom to run, study, modify, and redistribute software.\n",
     "\n",
-    "3. **License Categories:** Understanding the differences between proprietary, source available, permissive open source, and copyleft licenses is crucial.\n",
+    "3. **Free vs. Open Source:** While related, \"free software\" emphasizes user freedom while \"open source\" emphasizes practical benefits.\n",
     "\n",
-    "4. **Free vs. Open Source:** While related, \"free software\" emphasizes user freedom while \"open source\" emphasizes practical benefits.\n",
+    "4. **Modern Relevance:** The principles behind the printer story remain relevant today as proprietary software continues to impose arbitrary restrictions.\n",
     "\n",
-    "5. **Modern Relevance:** The principles behind the printer story remain relevant today as proprietary software continues to impose arbitrary restrictions.\n",
-    "\n",
-    "6. **Economic Impact:** Open source succeeds because it harnesses collective intelligence, enhances security, reduces costs, and prevents vendor lock-in.\n",
-    "\n",
-    "### Reflection Questions\n",
-    "\n",
-    "- Have you ever encountered software restrictions that prevented you from doing something useful?\n",
-    "- How might your organization benefit from adopting more open source software?\n",
-    "- What do I think about the possibility of my code being used in a proprietary project? Am I comfortable with that?\n",
-    "- Should I consider using a copyleft license (**like OSPO's recommended LGPLv3**) for my project, or is a permissive license (**like Apache 2.0**) more suitable for my next project?\n",
+    "5. **Economic Impact:** Open source succeeds because it harnesses collective intelligence, enhances security, reduces costs, and prevents vendor lock-in.\n",
     "\n",
     "---\n",
     "\n",
@@ -259,8 +285,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Removes licensing content from L00 - History. This content has now moved to L01 - Licensing in a separate pull request.